### PR TITLE
Added Support for Grouped Tabs (Chrome) 

### DIFF
--- a/background.js
+++ b/background.js
@@ -3,10 +3,276 @@
  * @author Vedant Wakalkar <vedantwakalkar@gmail.com>
  */
 
+/**
+ * Firefox			1
+ * Google Chrome	2
+ */
+let browserDetected = 1;
+
+// Browser's API Object. 
+let browserAPI;
+
 try {
-	browser.browserAction.onClicked.addListener(() => {
-		browser.sidebarAction.toggle();
-	});	
+	// Firefox
+	browserAPI = browser;
 } catch (error) {
-	console.log(error);
+	// Chrome
+	browserDetected = 2;
+	browserAPI = chrome;
 }
+
+// Keep track of all Logs and emptied when stored in local storage. 
+let LoggerQueue = [];
+
+/**
+ * Logs message to LoggerQueue.
+ * @version    1.0.0
+ * @param    {String} message	Message to be logged.
+ */
+const logger = (message) => {
+	LoggerQueue.unshift({
+		time: new Date().valueOf(),
+		message: message,
+	});
+};
+
+/**
+ * Logging error or success message.
+ * @version	1.0.0
+ * @param	{Object}	delta		Object returned from Promise.
+ * @param	{String} 	messageType Type of Message
+ */
+const logErrorOrSuccess = (messageType, delta) => {
+	switch (messageType) {
+		case `error`:
+			logger(delta.message || delta);
+			break;
+		case `newTabCreated`:
+			logger(
+				`Created new tab for ${(
+					delta.status === "loading" ? delta.pendingUrl : delta.title
+				).italics()}`
+			);
+			break;
+		case `newGroupCreated`:
+			logger(
+				`Tabs successfully grouped ${delta.title === "" ? "." : "(" + delta.title.bold().italics() + ")."
+				}`
+			);
+			break;
+	}
+};
+
+/**
+ * Functionality to parse and create tabs and groups from recevied list of metadata of tabs and groups.
+ * @version    1.0.0
+ * @param    {Object} fileContent	Contains list of meta data of tabs and groups (if any).
+ */
+const importTabs = (fileContent) => {
+	// Extract list of tabs
+	const listOfTabs = fileContent.tabs;
+
+	// Group Tabs Queue to keep track of completion of tabGroups promise.
+	const groupTabsQueue = new Map();
+
+	// Array of Promises requested.
+	const groupedTabsPromiseArray = [];
+
+	for (const tab of listOfTabs) {
+		if (browserDetected == 1 || tab.groupId === undefined || tab.groupId == -1) {
+			// 1. If tabs are opened in FireFox
+			// 2. For Tabs which are not grouped.
+
+			// Create tab and log outcome. 
+			browserAPI.tabs
+				.create({
+					url: tab.url,
+				})
+				.then(
+					logErrorOrSuccess.bind(null, `newTabCreated`),
+					logErrorOrSuccess.bind(null, `error`)
+				);
+		} else {
+			// Check if URL to be grouped.
+			if (groupTabsQueue.has(tab.url)) {
+				const getGroup = groupTabsQueue.get(tab.url);
+
+				getGroup.set(
+					tab.groupId,
+					getGroup.has(tab.groupId) ? getGroup.get(tab.groupId) + 1 : 1
+				);
+
+				groupTabsQueue.set(tab.url, getGroup);
+			} else {
+				groupTabsQueue.set(tab.url, new Map([[tab.groupId, 1]]));
+			}
+
+			groupedTabsPromiseArray.push(
+				// Create tab 
+				browserAPI.tabs.create({
+					url: tab.url,
+					active: false,
+				})
+			);
+		}
+	}
+
+	/**
+	 * Store all logs from LoggerQueue to Local Storage.
+	 * @version    1.0.0
+	 */
+	const insertNewLogs = () => {
+		// Check if 'saveTabs' in present or not.
+		browserAPI.storage.local.get(`saveTabs`, (object) => {
+
+			setTimeout(() => {
+				let FinalLogsQueue = [];
+
+				// Latest logged message time.
+				const updated_at = LoggerQueue[0].time;
+
+				if (
+					object &&
+					Object.keys(object).length === 0 &&
+					object.constructor === Object
+				) {
+					FinalLogsQueue = LoggerQueue;
+				} else {
+					object.saveTabs.logs.unshift(...LoggerQueue);
+					FinalLogsQueue = object.saveTabs.logs;
+				}
+
+				// Store logs to local storage and then empty LoggerQueue.
+				browserAPI.storage.local.set(
+					{
+						saveTabs: {
+							logs: FinalLogsQueue,
+							updated_at: updated_at,
+						},
+					},
+					() => {
+						LoggerQueue = [];
+					}
+				);
+			}, 1000);
+		});
+	};
+
+	/**
+	 * Store all logs from LoggerQueue to Local Storage.
+	 * @version    1.0.0
+	 * @param    {Object} metaData	Meta data of groups with list of respective tabs to be grouped. 
+	 */
+	const moveTabsToGroups = (metaData) => {
+		metaData.forEach((group) => {
+			// Create new Group with tabs listed. 
+			browserAPI.tabs.group({
+				tabIds: group.tabs
+			})
+				.then((delta) => {
+
+					(group.title === ``) ?
+						// If group title in empty
+						logErrorOrSuccess.bind(null, `newGroupCreated`) :
+						// Update Group with title name
+						browserAPI.tabGroups
+							.update(delta, {
+								title: group.title,
+								collapsed: true,
+							})
+							.then(
+								logErrorOrSuccess.bind(null, `newGroupCreated`),
+								logErrorOrSuccess.bind(null, `error`)
+							);
+				}, logErrorOrSuccess.bind(null, `error`));
+		});
+
+		// To store all logs in local storage.
+		insertNewLogs();
+	};
+
+	if (browserDetected == 1 || fileContent.groups === undefined) {
+		// 1. If FireFox.
+		// 2. If no grouped tabs are present.
+
+		// To store all logs in local storage.
+		insertNewLogs();
+	} else {
+		// Meta Data of newly created tabs to be grouped.
+		const groupMetaData = new Map();
+
+		// To check if all promised are fulfilled.
+		Promise.allSettled(groupedTabsPromiseArray).then((results) => {
+			results.forEach((result) => {
+				// Get URL
+				const url = result.value.url || result.value.pendingUrl;
+
+				// URL to be grouped in.
+				const groupsRelatedToURL = groupTabsQueue.get(url);
+
+				// Group Id
+				const groupIdForTab = groupsRelatedToURL.keys().next().value;
+
+				const groupIdCount = groupsRelatedToURL.get(groupIdForTab);
+
+				if (groupIdCount == 1) {
+					((groupsRelatedToURL.size == 1) ?
+						groupTabsQueue.delete(url) :
+						groupsRelatedToURL.delete(groupIdForTab));
+				} else {
+					groupsRelatedToURL.set(groupIdForTab, groupIdCount - 1);
+					groupTabsQueue.set(url, groupsRelatedToURL);
+				}
+
+				const metaData = {
+					title: fileContent.groups[groupIdForTab].title,
+				};
+
+				if (!groupMetaData.has(groupIdForTab)) {
+					metaData[`tabs`] = [result.value.id];
+				} else {
+					metaData[`tabs`] = groupMetaData.get(groupIdForTab).tabs;
+					metaData.tabs.push(result.value.id);
+				}
+
+				// Set meta data for respective Group.
+				groupMetaData.set(groupIdForTab, metaData);
+
+				// Log sucessful creation of tab.
+				logErrorOrSuccess.bind(null, `newTabCreated`);
+
+				// If all promises are fulfilled then group tabs.
+				if (groupTabsQueue.size == 0) {
+					moveTabsToGroups(groupMetaData);
+				}
+			});
+		}, logErrorOrSuccess.bind(null, `error`));
+	}
+};
+
+/**
+ * Interpret message received.
+ * @version    1.0.0
+ * @param    {Object} message		Message Object containing request and data.
+ * @param    {Object} sendResponse	Function to respond recevier with parameters as Message Object.
+ */
+const interpretRequest = (message, sender, sendResponse) => {
+	// Check if requesting for import tabs functionality
+	if (message.type === `imported_file_content`) {
+		importTabs(message.data);
+		sendResponse(`Request Submitted Successfully!`);
+	}
+};
+
+// Listener to listen message received from saveTabs.js
+browserAPI.runtime.onMessage.addListener(interpretRequest);
+
+if (browserDetected == 1)
+	try {
+		// To toggle sidebar of Firefox browser 
+		browserAPI.browserAction.onClicked.addListener(() => {
+			browserAPI.sidebarAction.toggle();
+		});
+	} catch (error) {
+		console.log(error);
+	}

--- a/manifest-chrome.json
+++ b/manifest-chrome.json
@@ -1,12 +1,15 @@
-// manifest.json for Chrome Extension.
-
 {
-	"manifest_version": 3,
+	"manifest_version": 2,
 	"name": "Save Tabs",
 	"version": "1.0",
 
 	"description": "Export and Import Tabs.",
 	"homepage_url": "https://github.com/karna98/Save-Tabs",
+
+	"developer": {
+		"name": "Vedant Wakalkar",
+		"url": "https://karna98.github.io"
+	},
 
 	"icons": {
 		"16": "icons/Save_Tabs_16.png",
@@ -19,12 +22,31 @@
 
 	"permissions": [
 		"tabs",
-		"downloads"
+		"downloads",
+		"storage"
 	],
 
-	"incognito": "split",
-	
-	"action": {
+	// "incognito": "split",  /* Bug for 'split' */
+
+	"browser_action": {
+		"default_icon": {
+			"16": "icons/Save_Tabs_16.png",
+			"32": "icons/Save_Tabs_32.png",
+			"48": "icons/Save_Tabs_48.png",
+			"64": "icons/Save_Tabs_64.png",
+			"96": "icons/Save_Tabs_96.png",
+			"128": "icons/Save_Tabs_128.png"
+		},
+		"default_title": "Save Tabs"
+	},
+
+	"background": {
+		"scripts":[
+			"background.js"
+		]
+	},
+
+	"sidebar_action": {
 		"default_icon": {
 			"16": "icons/Save_Tabs_16.png",
 			"32": "icons/Save_Tabs_32.png",
@@ -34,6 +56,6 @@
 			"128": "icons/Save_Tabs_128.png"
 		},
 		"default_title": "Save Tabs",
-		"default_popup": "saveTab.html"
+		"default_panel": "saveTab.html"
 	}
 }

--- a/manifest-chrome.json
+++ b/manifest-chrome.json
@@ -1,15 +1,10 @@
 {
-	"manifest_version": 2,
+	"manifest_version": 3,
 	"name": "Save Tabs",
 	"version": "1.0",
 
 	"description": "Export and Import Tabs.",
 	"homepage_url": "https://github.com/karna98/Save-Tabs",
-
-	"developer": {
-		"name": "Vedant Wakalkar",
-		"url": "https://karna98.github.io"
-	},
 
 	"icons": {
 		"16": "icons/Save_Tabs_16.png",
@@ -22,31 +17,18 @@
 
 	"permissions": [
 		"tabs",
+		"tabGroups",
 		"downloads",
 		"storage"
 	],
 
-	// "incognito": "split",  /* Bug for 'split' */
-
-	"browser_action": {
-		"default_icon": {
-			"16": "icons/Save_Tabs_16.png",
-			"32": "icons/Save_Tabs_32.png",
-			"48": "icons/Save_Tabs_48.png",
-			"64": "icons/Save_Tabs_64.png",
-			"96": "icons/Save_Tabs_96.png",
-			"128": "icons/Save_Tabs_128.png"
-		},
-		"default_title": "Save Tabs"
-	},
-
+	"incognito": "split",
+	
 	"background": {
-		"scripts":[
-			"background.js"
-		]
+		"service_worker": "background.js"
 	},
 
-	"sidebar_action": {
+	"action": {
 		"default_icon": {
 			"16": "icons/Save_Tabs_16.png",
 			"32": "icons/Save_Tabs_32.png",
@@ -56,6 +38,6 @@
 			"128": "icons/Save_Tabs_128.png"
 		},
 		"default_title": "Save Tabs",
-		"default_panel": "saveTab.html"
+		"default_popup": "saveTab.html"
 	}
 }

--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -1,9 +1,7 @@
-// manifest.json for Firefox Extension.
-
 {
 	"manifest_version": 2,
 	"name": "Save Tabs",
-	"version": "1.0",
+	"version": "1.1",
 
 	"description": "Export and Import Tabs.",
 	"homepage_url": "https://github.com/karna98/Save-Tabs",

--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "Save Tabs",
-	"version": "1.1",
+	"version": "1.0",
 
 	"description": "Export and Import Tabs.",
 	"homepage_url": "https://github.com/karna98/Save-Tabs",
@@ -22,7 +22,8 @@
 
 	"permissions": [
 		"tabs",
-		"downloads"
+		"downloads",
+		"storage"
 	],
 
 	// "incognito": "split",  /* Bug for 'split' */

--- a/saveTab.js
+++ b/saveTab.js
@@ -3,306 +3,361 @@
  * @author Vedant Wakalkar <vedantwakalkar@gmail.com>
  */
 
- `use strict`;
+`use strict`;
 
- /**
-  * Extract values (ss, mm, hh, DD, MM, YYYY) from current timestamp.
-  * @version    1.0.0
-  * @return    {Array}    Array of extracted values from timestamps.
-  */
- const extractDateComponents = () => {
-   const currentTime = new Date();
- 
-   return [
-	 currentTime.getSeconds().toString().padStart(2, `0`), // seconds
-	 currentTime.getMinutes().toString().padStart(2, `0`), // minutes
-	 currentTime.getHours().toString().padStart(2, `0`), // hours
-	 currentTime.getDate().toString().padStart(2, `0`), // date
-	 currentTime.getMonth().toString().padStart(2, `0`), // month
-	 currentTime.getFullYear().toString().padStart(2, `0`), // year
-   ];
- };
- 
- /**
-  * Populates received message in Logs Section of Extension.
-  * @version    1.0.0
-  * @param    {Object} newLogObject	Object containing log time and message.
-  */
- const populateLogs = (newLogObject) => {
-   const logSection = document.getElementById(`logs`);
- 
-   if (logSection.innerText === ``) {
-	 const localStorageSaveTab = window.localStorage.getItem(`saveTabs`);
- 
-	 if (localStorageSaveTab != null) {
-	   const localStorageSaveTabObject = JSON.parse(localStorageSaveTab);
- 
-	   logSection.innerHTML = localStorageSaveTabObject.logs
-		 .map((log) => `<p> ${log.time.bold()} - ${log.message} </p>`)
-		 .join(`<br>`);
-	 }
-   } else {
-	 const p = document.createElement(`p`);
-	 p.innerHTML = `${newLogObject.time.bold()} - ${newLogObject.message} <br>`;
-	 logSection.insertBefore(p, logSection.firstChild);
-   }
- };
- 
- /**
-  * Logs and Populate received message.
-  * @version    1.0.0
-  * @param    {String} message	Message to be logged.
-  */
- const logger = (message) => {
-   const timeStamp = extractDateComponents();
-   const unixTmeStamp = Date.now();
-   const newLogTime = `${timeStamp[2]}:${timeStamp[1]}:${timeStamp[0]}`;
-   const newLogMessage = `{ "time" : "${newLogTime}", "message" : "${message}" }`;
-   const newLogObject = JSON.parse(newLogMessage);
- 
-   // Get 'saveTabs' from LocalStorage.
-   const localStorage = window.localStorage.getItem(`saveTabs`);
- 
-   if (localStorage == null) {
-	 // If 'saveTabs' not found in LocalStorage
-	 window.localStorage.setItem(
-	   `saveTabs`,
-	   `{ "updated_at": ${unixTmeStamp}, "logs" : [ ${newLogMessage} ] }`
-	 );
-   } else {
-	 const JSONObject = JSON.parse(localStorage);
-	 JSONObject.logs.unshift(newLogObject);
-	 JSONObject.updated_at = unixTmeStamp;
-	 window.localStorage.setItem(`saveTabs`, JSON.stringify(JSONObject));
-   }
- 
-   populateLogs(newLogObject);
- };
- 
- /**
-  * Logging unexpected error
-  * @version    1.0.0
-  * @param    {String} error   Error message
-  */
- const reportError = (error) => {
-   logger(error);
- };
- 
- /**
-  * Logging successful creation of tab for provided url.
-  * @version    1.0.0
-  * @param    {Object} tab	Newly create tab object.
-  */
- const newTabOnCreated = (tab) => {
-   logger(
-	 `Created new tab for ${(tab.status === "loading"
-	   ? tab.pendingUrl
-	   : tab.title
-	 ).italics()}`
-   );
- };
- 
- /**
-  * Read the uploaded file and open corresponding URLs in new tabs.
-  * @version    1.0.0
-  * @param    {Object} fileInput	Event Object of File Input when a file is uploaded.
-  */
- const importTabs = (fileInput) => {
-   // Read the data from uploaded file.
-   const file = fileInput.target.files[0];
- 
-   const reader = new FileReader();
-   reader.readAsText(file, `UTF-8`);
-   reader.onload = (e) => {
-	 const listOfTabs = JSON.parse(e.target.result).tabs;
- 
-	 for (const url of listOfTabs) {
-	   try {
-		 // For Firefox
-		 const newTab = browser.tabs.create({
-		   url: url,
-		 });
- 
-		 newTab.then(newTabOnCreated, reportError);
-	   } catch (error) {
-		 try {
-		   // For Chrome
-		   const newTab = chrome.tabs.create({
-			 url: url,
-		   });
- 
-		   newTab.then(newTabOnCreated, reportError);
-		 } catch (error) {
-		   console.log(error);
-		 }
-	   }
-	 }
-   };
- };
- 
- /**
-  * Returns default or user input file name.
-  * Default File Name Format : "Save_Tabs_DD-MM-YYYY-hh-mm-ss.json"
-  * @version    1.0.0
-  * @return   	{String}	Name of the file.
-  */
- const getFilename = () => {
-   const filenameElement = document.getElementById(`file-name`);
- 
-   const fileName = filenameElement.value.trim().replace(/[^\w\s_\(\)\-]/gi, ``);
- 
-   if (fileName == ``) {
-	 // Default File Name.
-	 const currentTime = extractDateComponents();
-	 return `Save_Tabs_${currentTime[3]}-${currentTime[4]}-${currentTime[5]}-${currentTime[2]}-${currentTime[1]}-${currentTime[0]}.json`;
-   } else {
-	 // User Input File Name.
-	 return `${fileName}.json`;
-   }
- };
- 
- /**
-  * Download file (in JSON format) containing list of all open tabs.
-  * @version    1.0.0
-  * @param    {Object} tabs	Detailed array of all open Tabs.
-  */
- const downloadFile = (tabs) => {
-   // Download Queue to keep track of each download event.
-   const downloadQueue = new Map();
- 
-   const fileContent = `{ "tabs" : [ ${tabs
-	 .map((tab) => '"' + tab.url + '"')
-	 .join(",")} ] }`;
- 
-   // Create a Blob of fileContent
-   const file = new Blob([fileContent], {
-	 type: `plain/text`,
-   });
- 
-   const fileName = getFilename();
-   const url = window.URL.createObjectURL(file);
- 
-   const metaData = {
-	 url: url,
-	 filename: fileName,
-	 saveAs: true,
-	 conflictAction: `uniquify`,
-   };
- 
-   logger(`Ready for download - ${fileName.italics()}`);
- 
-   try {
-	 browser.downloads.download(metaData).then(
-	   (id) => {
-		 downloadQueue.set(id, { url, fileName });
-		 browser.downloads.onChanged.addListener(onChangedListener);
-	   },
-	   (error) => {
-		 logger(`Download interrupted - ${fileName.italics()}`);
-	   }
-	 );
-   } catch (error) {
-	 chrome.downloads.download(metaData, (id) => {
-	   downloadQueue.set(id, { url, fileName });
-	   chrome.downloads.onChanged.addListener(onChangedListener);
-	 });
-   }
- 
-   /**
-	* To check if file has completed download or not.
-	* @version    1.0.0
-	* @param    {Object} delta		Object of download intiated file.
-	*/
-   const onChangedListener = (delta) => {
-	 if (
-	   downloadQueue.has(delta.id) &&
-	   delta.state &&
-	   delta.state.current !== `in_progress`
-	 ) {
-	   // Check if the download ID present in download queue. If present then check status.
- 
-	   const mappedValueForID = downloadQueue.get(delta.id);
- 
-	   // Delete entry for download ID from download queue.
-	   downloadQueue.delete(delta.id);
- 
-	   // Revoke File URL created.
-	   window.URL.revokeObjectURL(mappedValueForID.url);
- 
-	   logger(
-		 `Download ${
-		   delta.state.current
-		 } - ${mappedValueForID.fileName.italics()}`
-	   );
- 
-	   try {
-		 browser.downloads.onChanged.removeListener(onChangedListener);
-	   } catch (error) {
-		 chrome.downloads.onChanged.removeListener(onChangedListener);
-	   }
-	 }
-   };
- };
- 
- /**
-  * Query browser window to get list of all open tabs.
-  * On successfull query, file is downloaded or error is logged on failure.
-  * @version    1.0.0
-  */
- const exportTabs = () => {
-   try {
-	 browser.tabs
-	   .query({
-		 currentWindow: true,
-	   })
-	   .then(downloadFile, reportError);
-   } catch (error) {
-	 try {
-	   chrome.tabs
-		 .query({
-		   currentWindow: true,
-		 })
-		 .then(downloadFile, reportError);
-	 } catch (error) {
-	   console.log(error);
-	 }
-   }
- };
- 
- /**
-  * Checks and deletes (older than 10 mins) data stored in localstorage
-  * @version    1.0.0
-  */
- const localStorageExpiryCheck = () => {
-   const localStorageSaveTab = window.localStorage.getItem(`saveTabs`);
- 
-   if (localStorageSaveTab != null) {
-	 const JSONObject = JSON.parse(localStorageSaveTab);
- 
-	 // Calculate age of stored data.
-	 const timeDifference = (Date.now() - JSONObject.updated_at) / 60000;
- 
-	 if (timeDifference > 10.0) window.localStorage.removeItem(`saveTabs`);
-   }
- };
- 
- /**
-  * Intializes required checks and listeners.
-  * @version    1.0.0
-  */
- const init = () => {
-   // Check and Clear (old than 10 minutes) data stored.
-   localStorageExpiryCheck();
- 
-   // Sync logs with data in local storage.
-   populateLogs(``);
- 
-   // Detect if file is selected using HTML input file.
-   document.getElementById(`file`).addEventListener(`change`, importTabs);
- 
-   // Listen on clicking Export button.
-   document.getElementById(`export`).addEventListener(`click`, exportTabs);
- };
- 
- init();
- 
+window.addEventListener(`DOMContentLoaded`, () => {
+	/**
+	 * Firefox			1
+	 * Google Chrome	2
+	 */
+	let browserDetected = 1;
+
+	// Browser's API Object. 
+	let browserAPI;
+
+	try {
+		// Firefox
+		browserAPI = browser;
+	} catch (error) {
+		// Chrome
+		browserDetected = 2;
+		browserAPI = chrome;
+	}
+
+	/**
+	 * Store logs in local storage.
+	 * @version    1.1.0
+	 * @param    {String} message	Logged Message.
+	 */
+	const logger = (message) => {
+		const logObject = {
+			time: new Date().valueOf(),
+			message: message,
+		};
+
+		// Check if 'saveTabs' in present or not.
+		browserAPI.storage.local.get(`saveTabs`, (object) => {
+			// Latest logged message time.
+			const updated_at = logObject.time;
+			let FinalLogsQueue;
+			if (
+				object &&
+				Object.keys(object).length === 0 &&
+				object.constructor === Object
+			) {
+				FinalLogsQueue = [logObject];
+			} else {
+				object.saveTabs.logs.unshift(logObject);
+				FinalLogsQueue = object.saveTabs.logs;
+			}
+
+			// Store logs to local storage and then empty LoggerQueue.
+			browserAPI.storage.local.set(
+				{
+					saveTabs: {
+						logs: FinalLogsQueue,
+						updated_at: updated_at,
+					},
+				});
+		});
+	};
+
+	/**
+	 * Populates Logs Section of Extension by logs stored in local storage.
+	 * @version    1.1.0
+	 */
+	const populateLogs = () => {
+		// DOM of log section.
+		const logSection = document.getElementById(`logs`);
+
+		// Get logs from local storage
+		browserAPI.storage.local.get(`saveTabs`, (object) => {
+			if (object.saveTabs !== undefined) {
+				logSection.innerHTML = object.saveTabs.logs
+					.map(
+						(log) =>
+							`<p> ${new Date(log.time).toLocaleTimeString().bold()} - ${log.message
+							} </p>`
+					)
+					.join(`<br>`);
+			}
+		});
+	};
+
+	/**
+	 * Logging error or success message.
+	 * @version	1.0.0
+	 * @param	{Object}	delta		Object returned from Promise.
+	 * @param	{String} 	messageType Type of Message
+	 */
+	const logErrorOrSuccess = (messageType, delta) => {
+		switch (messageType) {
+			case `error`:
+				logger(delta.message || delta);
+				break;
+			case `readyForDownload`:
+				logger(`Ready for download - ${delta.fileName.italics()}`);
+				break;
+			case `downloadedStatus`:
+				logger(`Download ${delta.state} - ${delta.fileName.italics()}`);
+				break;
+		}
+	};
+
+	/**
+	 * Read the uploaded file and open corresponding URLs in new tabs.
+	 * @version    1.1.0
+	 * @param    {Object} fileInput	Event Object of File Input when a file is uploaded.
+	 */
+	const importTabs = (fileInput) => {
+		// Read the data from uploaded file.
+		const file = fileInput.target.files[0];
+
+		const reader = new FileReader();
+		reader.readAsText(file, `UTF-8`);
+		reader.onload = (e) => {
+			const fileContent = JSON.parse(e.target.result);
+
+			// Send Message to background.js to run creation of tabs any group.
+			browserAPI.runtime.sendMessage(
+				{
+					type: `imported_file_content`,
+					data: fileContent,
+				},
+				(response) => {
+					try {
+						console.log(response);
+					} catch (error) {
+						console.log(error);
+					}
+				}
+			);
+		};
+	};
+
+	/**
+	 * Returns default or user input file name.
+	 * Default File Name Format : "Save_Tabs_DD-MM-YYYY-hh-mm-ss-*M.json"
+	 * @version    1.0.0
+	 * @return   	{String}	Name of the file.
+	 */
+	const getFilename = () => {
+		const filenameElement = document.getElementById(`file-name`);
+
+		const fileName = filenameElement.value
+			.trim()
+			.replace(/[^\w\s_\(\)\-]/gi, ``);
+
+		if (fileName == ``) {
+			// Default File Name.
+			return `Save_Tabs_${new Date()
+				.toLocaleString()
+				.replaceAll(/(, )| /g, '_')
+				.replaceAll(/[,://]/g, '-')}.json`;
+		} else {
+			// User Input File Name.
+			return `${fileName}.json`;
+		}
+	};
+
+	/**
+	 * Download file (in JSON format) containing list of all open tabs.
+	 * @version    1.1.0
+	 * @param    {Object} tabs	Detailed array of all open Tabs.
+	 */
+	const downloadFile = (tabs) => {
+		// Download Queue to keep track of each download event.
+		const downloadQueue = new Map();
+
+		// Group Tabs Promise Queue to keep track of completion of tabGroups promise.
+		const groupTabsQueue = new Map();
+
+		// Promise array to keep track of all promises requested.
+		let promiseArray = [];
+
+		// Structure of file which will be downloaded
+		let fileContent = Object({
+			tabs: [],
+		});
+
+		/**
+		 * To check if file has completed download or not.
+		 * @version    1.0.0
+		 * @param    {Object} delta		Object of download intiated file.
+		 */
+		const onChangedListener = (delta) => {
+			if (
+				downloadQueue.has(delta.id) &&
+				delta.state &&
+				delta.state.current !== `in_progress`
+			) {
+				// Check if the download ID present in download queue. If present then check status.
+				const mappedValueForID = downloadQueue.get(delta.id);
+
+				// Delete entry for download ID from download queue.
+				downloadQueue.delete(delta.id);
+
+				// Revoke File URL created.
+				window.URL.revokeObjectURL(mappedValueForID.url);
+
+				logErrorOrSuccess(`downloadedStatus`, {
+					state: delta.state.current,
+					fileName: mappedValueForID.fileName,
+				});
+
+				// Remove Listener
+				browserAPI.downloads.onChanged.removeListener(onChangedListener);
+			}
+		};
+
+		/**
+		 * Convert File Content Object to blob and downloads file.
+		 * @version    1.0.0
+		 * @param    {Object} fileContent	Object containing data related to tabs.
+		 */
+		const initiateDownload = (fileContent) => {
+			// Create Blob of file content
+			const file = new Blob([JSON.stringify(fileContent)], {
+				type: `plain/text`,
+			});
+
+			// Get file name
+			const fileName = getFilename();
+
+			// Create URL of Blob file
+			const url = window.URL.createObjectURL(file);
+
+			const metaData = {
+				url: url,
+				filename: fileName,
+				saveAs: true,
+				conflictAction: `uniquify`,
+			};
+
+			logErrorOrSuccess(`readyForDownload`, {
+				fileName: fileName,
+			});
+
+			try {
+				// Firefox
+				browserAPI.downloads.download(metaData).then(
+					(id) => {
+						downloadQueue.set(id, { url, fileName });
+
+						// Add Listener to keep track of download
+						browserAPI.downloads.onChanged.addListener(onChangedListener);
+					},
+					() => {
+						logErrorOrSuccess(`downloadedStatus`, {
+							state: `interrupted`,
+							fileName: fileName,
+						});
+					}
+				);
+			} catch (error) {
+				// Chrome
+				browserAPI.downloads.download(metaData, (id) => {
+					downloadQueue.set(id, { url, fileName });
+
+					// Add Listener to keep track of download
+					browserAPI.downloads.onChanged.addListener(onChangedListener);
+				});
+			}
+		};
+
+		// Restructuring tabs with required details (url and groupId)
+		tabs.map((tab) => {
+			if (tab.groupId === undefined || tab.groupId == -1) {
+				fileContent.tabs.push({
+					url: tab.url,
+				});
+			} else {
+				fileContent.tabs.push({
+					url: tab.url,
+					groupId: tab.groupId,
+				});
+
+				if (tab.groupId != -1 && !groupTabsQueue.has(tab.groupId)) {
+					groupTabsQueue.set(tab.groupId, 1);
+					promiseArray.push(browserAPI.tabGroups.get(tab.groupId));
+				}
+			}
+		});
+
+		if (!groupTabsQueue.size || promiseArray.length) {
+			// if group details are requested
+			Promise.allSettled(promiseArray).then((results) => {
+				results.forEach((result) => {
+					groupTabsQueue.delete(result.value.id);
+
+					if (fileContent.groups === undefined) {
+						fileContent[`groups`] = {};
+					}
+
+					fileContent.groups[result.value.id] = {
+						title: result.value.title,
+					};
+
+					// If all promises are fulfilled then intiate download.
+					if (groupTabsQueue.size == 0) {
+						initiateDownload(fileContent);
+					}
+				});
+			}, logErrorOrSuccess.bind(null, `error`));
+		} else {
+			// If no group details request initiated.
+			initiateDownload(fileContent);
+		}
+	};
+
+	/**
+	 * Query browser window to get list of all open tabs.
+	 * On successfull query, file is downloaded or error is logged on failure.
+	 * @version    1.0.0
+	 */
+	const exportTabs = () => {
+		// Get list all tabs open in current browser window
+		browserAPI.tabs
+			.query({
+				currentWindow: true,
+			})
+			.then(downloadFile, logErrorOrSuccess.bind(null, `error`));
+	};
+
+	/**
+	 * Checks and deletes (older than 10 mins) data stored in localstorage
+	 * @version    1.0.0
+	 */
+	const localStorageExpiryCheck = () => {
+		// Check if 'saveTabs' in present or not.
+		browserAPI.storage.local.get(`saveTabs`, (object) => {
+			if (object.saveTabs !== undefined)
+				(Date.now() - object.saveTabs.updated_at > 600000) ?
+					browserAPI.storage.local.clear() : populateLogs();
+		});
+	};
+
+	/**
+	 * Intializes required checks and listeners.
+	 * @version    1.0.0
+	 */
+	const init = () => {
+		// Check and Clear (old than 10 minutes) data stored.
+		localStorageExpiryCheck();
+
+		// Detect if file is selected using HTML input file.
+		document.getElementById(`file`).addEventListener(`change`, importTabs);
+
+		// Listen on clicking Export button.
+		document.getElementById(`export`).addEventListener(`click`, exportTabs);
+
+		// Sync updated storage under Logs section
+		browserAPI.storage.onChanged.addListener((changes, area) => {
+			if (area === `local` && changes.saveTabs !== undefined) {
+				populateLogs();
+			}
+		});
+	};
+
+	init();
+});

--- a/saveTab.js
+++ b/saveTab.js
@@ -12,7 +12,7 @@ window.addEventListener(`DOMContentLoaded`, () => {
 	 */
 	let browserDetected = 1;
 
-	// Browser's API Object. 
+	// Browser's API Object.
 	let browserAPI;
 
 	try {
@@ -32,7 +32,7 @@ window.addEventListener(`DOMContentLoaded`, () => {
 	const logger = (message) => {
 		const logObject = {
 			time: new Date().valueOf(),
-			message: message,
+			message: message
 		};
 
 		// Check if 'saveTabs' in present or not.
@@ -52,13 +52,12 @@ window.addEventListener(`DOMContentLoaded`, () => {
 			}
 
 			// Store logs to local storage and then empty LoggerQueue.
-			browserAPI.storage.local.set(
-				{
-					saveTabs: {
-						logs: FinalLogsQueue,
-						updated_at: updated_at,
-					},
-				});
+			browserAPI.storage.local.set({
+				saveTabs: {
+					logs: FinalLogsQueue,
+					updated_at: updated_at
+				}
+			});
 		});
 	};
 
@@ -122,7 +121,7 @@ window.addEventListener(`DOMContentLoaded`, () => {
 			browserAPI.runtime.sendMessage(
 				{
 					type: `imported_file_content`,
-					data: fileContent,
+					data: fileContent
 				},
 				(response) => {
 					try {
@@ -152,8 +151,8 @@ window.addEventListener(`DOMContentLoaded`, () => {
 			// Default File Name.
 			return `Save_Tabs_${new Date()
 				.toLocaleString()
-				.replaceAll(/(, )| /g, '_')
-				.replaceAll(/[,://]/g, '-')}.json`;
+				.replaceAll(/(, )| /g, "_")
+				.replaceAll(/[,://]/g, "-")}.json`;
 		} else {
 			// User Input File Name.
 			return `${fileName}.json`;
@@ -177,7 +176,7 @@ window.addEventListener(`DOMContentLoaded`, () => {
 
 		// Structure of file which will be downloaded
 		let fileContent = Object({
-			tabs: [],
+			tabs: []
 		});
 
 		/**
@@ -202,7 +201,7 @@ window.addEventListener(`DOMContentLoaded`, () => {
 
 				logErrorOrSuccess(`downloadedStatus`, {
 					state: delta.state.current,
-					fileName: mappedValueForID.fileName,
+					fileName: mappedValueForID.fileName
 				});
 
 				// Remove Listener
@@ -218,7 +217,7 @@ window.addEventListener(`DOMContentLoaded`, () => {
 		const initiateDownload = (fileContent) => {
 			// Create Blob of file content
 			const file = new Blob([JSON.stringify(fileContent)], {
-				type: `plain/text`,
+				type: `plain/text`
 			});
 
 			// Get file name
@@ -231,33 +230,38 @@ window.addEventListener(`DOMContentLoaded`, () => {
 				url: url,
 				filename: fileName,
 				saveAs: true,
-				conflictAction: `uniquify`,
+				conflictAction: `uniquify`
 			};
 
 			logErrorOrSuccess(`readyForDownload`, {
-				fileName: fileName,
+				fileName: fileName
 			});
 
-			try {
+			if (browserDetected == 1) {
 				// Firefox
 				browserAPI.downloads.download(metaData).then(
 					(id) => {
-						downloadQueue.set(id, { url, fileName });
+						downloadQueue.set(id, {
+							url,
+							fileName
+						});
 
 						// Add Listener to keep track of download
 						browserAPI.downloads.onChanged.addListener(onChangedListener);
-					},
-					() => {
+					}, () => {
 						logErrorOrSuccess(`downloadedStatus`, {
 							state: `interrupted`,
-							fileName: fileName,
+							fileName: fileName
 						});
 					}
 				);
-			} catch (error) {
+			} else {
 				// Chrome
 				browserAPI.downloads.download(metaData, (id) => {
-					downloadQueue.set(id, { url, fileName });
+					downloadQueue.set(id, {
+						url,
+						fileName
+					});
 
 					// Add Listener to keep track of download
 					browserAPI.downloads.onChanged.addListener(onChangedListener);
@@ -269,12 +273,12 @@ window.addEventListener(`DOMContentLoaded`, () => {
 		tabs.map((tab) => {
 			if (tab.groupId === undefined || tab.groupId == -1) {
 				fileContent.tabs.push({
-					url: tab.url,
+					url: tab.url
 				});
 			} else {
 				fileContent.tabs.push({
 					url: tab.url,
-					groupId: tab.groupId,
+					groupId: tab.groupId
 				});
 
 				if (tab.groupId != -1 && !groupTabsQueue.has(tab.groupId)) {
@@ -284,7 +288,7 @@ window.addEventListener(`DOMContentLoaded`, () => {
 			}
 		});
 
-		if (!groupTabsQueue.size || promiseArray.length) {
+		if (groupTabsQueue.size || promiseArray.length) {
 			// if group details are requested
 			Promise.allSettled(promiseArray).then((results) => {
 				results.forEach((result) => {
@@ -333,7 +337,8 @@ window.addEventListener(`DOMContentLoaded`, () => {
 		browserAPI.storage.local.get(`saveTabs`, (object) => {
 			if (object.saveTabs !== undefined)
 				(Date.now() - object.saveTabs.updated_at > 600000) ?
-					browserAPI.storage.local.clear() : populateLogs();
+					browserAPI.storage.local.clear() :
+					populateLogs();
 		});
 	};
 


### PR DESCRIPTION
## Changes: 
1. Restructured File Output format.
2. Migrated Import functionality to `background.js`
3. Added Support for Grouped Tabs. 
4. Migrated from `localStorageAPI` to `storage.local.*`.
5. Logs sync instantly.
6. Replaced `try..catch` for different browser API with a single variable that holds respective browser API on initialization of scripts.

## Issues
1.  ~In Google Chrome, on clicking the Export button, File Explorer opens twice or some time File Explorer does not open. (Intermittent)~

## Test
1. Cross-Browser Import Export working with the new file structure.
2. For Browser with no Tab Group functionality, all tabs will be created (as expected).
3. On Importing, Group Tabs with Group title is restored.

Solves Issue :   https://github.com/Karna98/Save-Tabs/issues/1